### PR TITLE
Latest updates

### DIFF
--- a/example/client-server/main.py
+++ b/example/client-server/main.py
@@ -70,17 +70,15 @@ def server_simple(request):
 @tracer.trace()
 def server_log(request):
     span = tracer.get_span(request)
-    if span is not None:
-        span.log_event('Hello, world!')
+    span.log_event('Hello, world!')
     return {'message': 'Something was logged'}
 
 @view_config(route_name='server_child_span', renderer='json')
 @tracer.trace()
 def server_child_span(request):
     span = tracer.get_span(request)
-    if span is not None:
-        child_span = tracer._tracer.start_span('child_span', child_of=span.context)
-        child_span.finish()
+    child_span = tracer._tracer.start_span('child_span', child_of=span.context)
+    child_span.finish()
     return {'message': 'A child span was created'}
 
 if __name__ == '__main__':

--- a/example/simple/main.py
+++ b/example/simple/main.py
@@ -20,8 +20,8 @@ def server_simple(request):
 @view_config(route_name='log', renderer='json')
 @tracer.trace()
 def server_log(request):
-    if tracer.get_span(request) is not None:
-        span.log_event('Hello, World!')
+    span = tracer.get_span(request)
+    span.log_event('Hello, World!')
     return { 'message': 'Something was logged' }
 
 if __name__ == '__main__':

--- a/pyramid_opentracing/tracer.py
+++ b/pyramid_opentracing/tracer.py
@@ -74,15 +74,15 @@ class PyramidTracer(object):
                 if payload:
                     span.set_tag(attr, payload)
 
+        # Put the component tag before finishing, so the user can override it.
+        span.set_tag('component', 'pyramid')
+
         return span
 
     def _finish_tracing(self, request, error=False):
         span = self._current_spans.pop(request, None)     
         if span is None:
             return
-
-        # Decorate some predefined tags.
-        span.set_tag('component', 'pyramid')
 
         if error:
             span.set_tag('error', 'true')

--- a/pyramid_opentracing/tracer.py
+++ b/pyramid_opentracing/tracer.py
@@ -52,7 +52,7 @@ class PyramidTracer(object):
         '''
         headers = request.headers
 
-        # use the path here - after calling the handler, we will get the resolved route.
+        # use the path (without GET arguments) as the operation name.
         operation_name = request.path
 
         # start new span from trace info
@@ -79,8 +79,6 @@ class PyramidTracer(object):
 
     def _finish_tracing(self, request):
         span = self._current_spans.pop(request, None)     
-        if span is not None and getattr(request, 'matched_route', None) is not None:
-            # Set the final resolved path, or else drop it (not found, redirected, etc).
-            span.operation_name = request.matched_route.name
+        if span is not None:
             span.finish()
 

--- a/pyramid_opentracing/tracer.py
+++ b/pyramid_opentracing/tracer.py
@@ -63,8 +63,6 @@ class PyramidTracer(object):
             span = self._tracer.start_span(operation_name=operation_name, child_of=span_ctx)
         except (opentracing.InvalidCarrierException, opentracing.SpanContextCorruptedException) as e:
             span = self._tracer.start_span(operation_name=operation_name)
-        if span is None:
-            span = self._tracer.start_span(operation_name=operation_name)
 
         # add span to current spans 
         self._current_spans[request] = span

--- a/pyramid_opentracing/tween_factory.py
+++ b/pyramid_opentracing/tween_factory.py
@@ -36,8 +36,11 @@ def opentracing_tween_factory(handler, registry):
         tracer._apply_tracing(req, traced_attrs)
         try:
             res = handler(req)
-        finally:
-            tracer._finish_tracing(req)
+        except:
+            tracer._finish_tracing(req, error=True)
+            raise
+
+        tracer._finish_tracing(req)
         return res
 
     return opentracing_tween


### PR DESCRIPTION
Applied the latest feedback:

* Trace *all* requests
* Include three predefined tags (component, pyramid.route, error)
* Clean the examples to remove the useless span != None check.
* Use path as the operation name (instead of the route name)

NOTE: Decided to not log the errors/exceptions as:
1) user/view exceptions are traced BUT not handled by ourselves, so no need to log them.
2) The SpanContextCorruptedException we get when applying tracing is thrown *even* not only for malformed headers, but also when there's *no* context information at all (which means: when we ourselves started the span). Logging that sounds like an overhead, no? (and there's no portable way to check this without having this exception being thrown).
3) The InvalidCarrierException happens when you pass an object which is not a dictionary, which NEVER happens (unless Pyramid itself gets corrupted or has a bug).